### PR TITLE
Implemented a "chunked" method of traversing the tree

### DIFF
--- a/src/partials.c
+++ b/src/partials.c
@@ -296,7 +296,7 @@ static void case_tiptip_range(pll_partition_t * partition,
                           unsigned int block_size
                           )
 {
-  const unsigned int clv_offset = block_start + partition->states * partition->rate_cats;
+  const unsigned int clv_offset = block_start * partition->states * partition->rate_cats;
   const double *left_matrix = partition->pmatrix[op->child1_matrix_index];
   const double *right_matrix = partition->pmatrix[op->child2_matrix_index];
   // TODO: Update to include rate categories
@@ -348,7 +348,7 @@ static void case_tipinner_range(pll_partition_t * partition,
                           unsigned int block_size
                           )
 {
-  const unsigned int clv_offset = block_start + partition->states * partition->rate_cats;
+  const unsigned int clv_offset = block_start * partition->states * partition->rate_cats;
   double * parent_clv = partition->clv[op->parent_clv_index] + clv_offset;
   unsigned int tip_clv_index;
   unsigned int inner_clv_index;
@@ -373,20 +373,20 @@ static void case_tipinner_range(pll_partition_t * partition,
   /* find which of the two child nodes is the tip */
   if (op->child1_clv_index < partition->tips)
   {
-    tip_clv_index = op->child1_clv_index + block_start;
+    tip_clv_index = op->child1_clv_index;
     tip_matrix_index = op->child1_matrix_index;
-    inner_clv_index = op->child2_clv_index + block_start;
+    inner_clv_index = op->child2_clv_index;
     inner_matrix_index = op->child2_matrix_index;
     if (op->child2_scaler_index == PLL_SCALE_BUFFER_NONE)
       right_scaler = NULL;
     else
-      right_scaler = partition->scale_buffer[op->child2_scaler_index];
+      right_scaler = partition->scale_buffer[op->child2_scaler_index] + block_start;
   }
   else
   {
-    tip_clv_index = op->child2_clv_index + block_start;
+    tip_clv_index = op->child2_clv_index;
     tip_matrix_index = op->child2_matrix_index;
-    inner_clv_index = op->child1_clv_index + block_start;
+    inner_clv_index = op->child1_clv_index;
     inner_matrix_index = op->child1_matrix_index;
     if (op->child1_scaler_index == PLL_SCALE_BUFFER_NONE)
       right_scaler = NULL;
@@ -400,8 +400,8 @@ static void case_tipinner_range(pll_partition_t * partition,
                              partition->rate_cats,
                              parent_clv,
                              parent_scaler,
-                             partition->tipchars[tip_clv_index],
-                             partition->clv[inner_clv_index],
+                             partition->tipchars[tip_clv_index] + block_start,
+                             partition->clv[inner_clv_index] + clv_offset,
                              partition->pmatrix[tip_matrix_index],
                              partition->pmatrix[inner_matrix_index],
                              right_scaler,

--- a/src/partials.c
+++ b/src/partials.c
@@ -296,7 +296,7 @@ static void case_tiptip_range(pll_partition_t * partition,
                           unsigned int block_size
                           )
 {
-  const unsigned int clv_offset = block_start + partition->sites * partition->rate_cats;
+  const unsigned int clv_offset = block_start + partition->states * partition->rate_cats;
   const double *left_matrix = partition->pmatrix[op->child1_matrix_index];
   const double *right_matrix = partition->pmatrix[op->child2_matrix_index];
   // TODO: Update to include rate categories
@@ -348,7 +348,7 @@ static void case_tipinner_range(pll_partition_t * partition,
                           unsigned int block_size
                           )
 {
-  const unsigned int clv_offset = block_start + partition->sites * partition->rate_cats;
+  const unsigned int clv_offset = block_start + partition->states * partition->rate_cats;
   double * parent_clv = partition->clv[op->parent_clv_index] + clv_offset;
   unsigned int tip_clv_index;
   unsigned int inner_clv_index;
@@ -419,7 +419,7 @@ static void case_innerinner_range(pll_partition_t * partition,
   const double *left_matrix = partition->pmatrix[op->child1_matrix_index];
   const double *right_matrix = partition->pmatrix[op->child2_matrix_index];
   const unsigned int clv_offset =
-      block_start * partition->sites * partition->rate_cats;
+      block_start * partition->states * partition->rate_cats;
   double *parent_clv = partition->clv[op->parent_clv_index] + clv_offset;
   double *left_clv = partition->clv[op->child1_clv_index] + clv_offset;
   double *right_clv = partition->clv[op->child2_clv_index] + clv_offset;

--- a/src/partials.c
+++ b/src/partials.c
@@ -296,10 +296,11 @@ static void case_tiptip_range(pll_partition_t * partition,
                           unsigned int block_size
                           )
 {
+  const unsigned int clv_offset = block_start + partition->sites * partition->rate_cats;
   const double *left_matrix = partition->pmatrix[op->child1_matrix_index];
   const double *right_matrix = partition->pmatrix[op->child2_matrix_index];
   // TODO: Update to include rate categories
-  double *parent_clv = partition->clv[op->parent_clv_index] + block_start;
+  double *parent_clv = partition->clv[op->parent_clv_index] + clv_offset;
   unsigned int *parent_scaler;
   unsigned int sites = block_start + block_size <= partition->sites
                            ? block_size
@@ -333,8 +334,8 @@ static void case_tiptip_range(pll_partition_t * partition,
                              partition->rate_cats,
                              parent_clv,
                              parent_scaler,
-                             partition->tipchars[op->child1_clv_index + block_start],
-                             partition->tipchars[op->child2_clv_index + block_start],
+                             partition->tipchars[op->child1_clv_index] + block_start,
+                             partition->tipchars[op->child2_clv_index] + block_start,
                              partition->tipmap,
                              partition->maxstates,
                              partition->ttlookup,
@@ -347,7 +348,8 @@ static void case_tipinner_range(pll_partition_t * partition,
                           unsigned int block_size
                           )
 {
-  double * parent_clv = partition->clv[op->parent_clv_index] + block_start;
+  const unsigned int clv_offset = block_start + partition->sites * partition->rate_cats;
+  double * parent_clv = partition->clv[op->parent_clv_index] + clv_offset;
   unsigned int tip_clv_index;
   unsigned int inner_clv_index;
   unsigned int tip_matrix_index;
@@ -414,14 +416,16 @@ static void case_innerinner_range(pll_partition_t * partition,
                           unsigned int block_size
                           )
 {
-  const double * left_matrix = partition->pmatrix[op->child1_matrix_index];
-  const double * right_matrix = partition->pmatrix[op->child2_matrix_index];
-  double * parent_clv = partition->clv[op->parent_clv_index] + block_start;
-  double * left_clv = partition->clv[op->child1_clv_index] + block_start;
-  double * right_clv = partition->clv[op->child2_clv_index] + block_start;
-  unsigned int * parent_scaler;
-  unsigned int * left_scaler;
-  unsigned int * right_scaler;
+  const double *left_matrix = partition->pmatrix[op->child1_matrix_index];
+  const double *right_matrix = partition->pmatrix[op->child2_matrix_index];
+  const unsigned int clv_offset =
+      block_start * partition->sites * partition->rate_cats;
+  double *parent_clv = partition->clv[op->parent_clv_index] + clv_offset;
+  double *left_clv = partition->clv[op->child1_clv_index] + clv_offset;
+  double *right_clv = partition->clv[op->child2_clv_index] + clv_offset;
+  unsigned int *parent_scaler;
+  unsigned int *left_scaler;
+  unsigned int *right_scaler;
   unsigned int sites = block_start + block_size <= partition->sites
                            ? block_size
                            : partition->sites - block_start;
@@ -479,7 +483,7 @@ PLL_EXPORT void pll_update_partials_blocked_rep(pll_partition_t * partition,
   unsigned int i, block_start;
   const pll_operation_t * op;
 
-  for (block_start = 0; block_start < partition->sites; block_start+= block_size)
+  for (block_start = 0; block_start < partition->sites; block_start += block_size)
   {
     for (i = 0; i < count; ++i)
     {

--- a/src/pll.h
+++ b/src/pll.h
@@ -785,6 +785,15 @@ PLL_EXPORT void pll_update_partials_rep(pll_partition_t *partition,
                                         const pll_operation_t *operations,
                                         unsigned int count,
                                         unsigned int update_repeats);
+PLL_EXPORT void pll_update_partials_blocked(pll_partition_t * partition,
+                                    const pll_operation_t * operations,
+                                    unsigned int count,
+                                    unsigned int block_size);
+PLL_EXPORT void pll_update_partials_blocked_rep(pll_partition_t * partition,
+                                    const pll_operation_t * operations,
+                                    unsigned int count,
+                                    unsigned int block_size,
+                                    unsigned int update_repeats);
 
 /* functions in derivatives.c */
 

--- a/test/src/partial-traversal.c
+++ b/test/src/partial-traversal.c
@@ -351,7 +351,7 @@ int main(int argc, char * argv[])
 
     /* use the operations array to compute all ops_count inner CLVs. Operations
        will be carried out sequentially starting from operation 0 towrds ops_count-1 */
-    pll_update_partials_blocked(partition, operations, ops_count, sites);
+    pll_update_partials_blocked(partition, operations, ops_count, sites/2);
     //pll_update_partials(partition, operations, ops_count);
     //
 

--- a/test/src/partial-traversal.c
+++ b/test/src/partial-traversal.c
@@ -351,12 +351,22 @@ int main(int argc, char * argv[])
 
     /* use the operations array to compute all ops_count inner CLVs. Operations
        will be carried out sequentially starting from operation 0 towrds ops_count-1 */
-    pll_update_partials(partition, operations, ops_count);
+    pll_update_partials_blocked(partition, operations, ops_count, sites);
+    //pll_update_partials(partition, operations, ops_count);
+    //
+
+    /*
+    for (unsigned int op_idx = 0; op_idx < ops_count; ++op_idx) {
+      pll_show_clv(partition, operations[op_idx].parent_clv_index,
+                   operations[op_idx].parent_scaler_index, 6);
+    }
+    */
 
     /* compute the likelihood on an edge of the unrooted tree by specifying
        the CLV indices at the two end-point of the branch, the probability matrix
        index for the concrete branch length, and the index of the model of whose
        frequency vector is to be used */
+    //double* persite = (double*) calloc(sites, sizeof(double));
     double logl = pll_compute_edge_loglikelihood(partition,
                                                  node->clv_index,
                                                  node->scaler_index,
@@ -365,6 +375,13 @@ int main(int argc, char * argv[])
                                                  node->pmatrix_index,
                                                  params_indices,
                                                  NULL);
+    /*
+    for(unsigned int pl = 0; pl < sites; ++pl){
+      printf("%f ", persite[pl]);
+    }
+    printf("\n");
+    free(persite);
+    */
 
     if (cmplogl >= -1)
       cmplogl = logl;


### PR DESCRIPTION
There is one complication here. When we have pattern tip optimization on, we precompute some results. In the normal method, we only need to compute and store one of these sets of results at a time. In this method, we will either need to compute the results multiple times, or store all the results.