### PR TITLE
Fix invalid forward declaration in yacc files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8.10 FATAL_ERROR)
+cmake_minimum_required (VERSION 2.8.10...3.20)
 
 project (Libpll)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.0.2...3.20)
 
 include(CheckIncludeFile) 
 

--- a/src/parse_rtree.y
+++ b/src/parse_rtree.y
@@ -32,7 +32,7 @@ extern int pll_rtree_lineno;
 extern int pll_rtree_colstart;
 extern int pll_rtree_colend;
 
-extern int pll_rtree_parse();
+extern int pll_rtree_parse(pll_rnode_t *);
 extern struct pll_rtree_buffer_state * pll_rtree__scan_string(const char * str);
 extern void pll_rtree__delete_buffer(struct pll_rtree_buffer_state * buffer);
 

--- a/src/parse_utree.y
+++ b/src/parse_utree.y
@@ -32,7 +32,7 @@ extern int pll_utree_lineno;
 extern int pll_utree_colstart;
 extern int pll_utree_colend;
 
-extern int pll_utree_parse();
+extern int pll_utree_parse(pll_unode_t *);
 extern struct pll_utree_buffer_state * pll_utree__scan_string(const char * str);
 extern void pll_utree__delete_buffer(struct pll_utree_buffer_state * buffer);
 


### PR DESCRIPTION
Hi!

This PR fixes invalid forward declarations in the yacc files `parse_utree.y` and `parse_rtree.y`, which prevent compilation of `libpll` (and dependents such as `raxml-ng`) with recent compilers.

At the moment, attempting to build with modern GCC fails (I tested with GCC 15.0):
```
In file included from /tmp/libpll-2/build/src/parse_utree.c:240:
/tmp/libpll-2/build/src/parse_utree.h:90:5: error: conflicting types for ‘pll_utree_parse’; have ‘int(struct pll_unode_s *)’
   90 | int pll_utree_parse (struct pll_unode_s * tree);
      |     ^~~~~~~~~~~~~~~
/tmp/libpll-2/src/parse_utree.y:35:12: note: previous declaration of ‘pll_utree_parse’ with type ‘int(void)’
   35 | extern int pll_utree_parse();
      |            ^~~~~~~~~~~~~~~
/tmp/libpll-2/build/src/parse_utree.c:68:25: error: conflicting types for ‘pll_utree_parse’; have ‘int(struct pll_unode_s *)’
   68 | #define yyparse         pll_utree_parse
      |                         ^~~~~~~~~~~~~~~
/tmp/libpll-2/build/src/parse_utree.c:1275:1: note: in expansion of macro ‘yyparse’
 1275 | yyparse (struct pll_unode_s * tree)
      | ^~~~~~~
/tmp/libpll-2/src/parse_utree.y:35:12: note: previous declaration of ‘pll_utree_parse’ with type ‘int(void)’
   35 | extern int pll_utree_parse();
      |            ^~~~~~~~
```

In addition, you may also want to update the `CMakeLists.txt` to more recent policies, so that it can build with modern versions. You can do so by updating the `policy_max` version in `cmake_minimum_required` like so:
```cmake
cmake_minimum_required(VERSION 2.8.10...3.10 FATAL_ERROR)
```
which would ensure support for both old and new CMake versions. I can include it in the PR if you want.

